### PR TITLE
Update requirements.txt

### DIFF
--- a/mysite/requirements.txt
+++ b/mysite/requirements.txt
@@ -6,5 +6,5 @@ gunicorn
 psycopg2
 tensorflow
 keras
-opencv-python
+opencv-python-headless
 pytz


### PR DESCRIPTION
changed opencv-python to opencv-python-headless as headless includes dependencies necessary for deployment.